### PR TITLE
refs #16 Supporting tablet

### DIFF
--- a/infoscoop-gadgets/gadgets/worldclock/css/worldclock-tablet.css
+++ b/infoscoop-gadgets/gadgets/worldclock/css/worldclock-tablet.css
@@ -2,24 +2,8 @@ body {
 	color: #34495E;
 }
 
-#main {
-	position:fixed;
-	top:0px;
-	left:0px;
-	bottom:0px;
-	right:0px;
-	margin:0px;
-}
-
-#content {
-	display : table;
-	width : 100%;
-	height : 100%;
-}
-
 #worldclock {
-	display : table-cell;
-	vertical-align: middle;
+	margin: 10px;
 	font-size: 13pt;
 	font-weight: normal;
 }


### PR DESCRIPTION
fixes bug that put unnecessary margin on the top of worldclock gadget.
